### PR TITLE
Added background color to differentiate Home player from Away player 

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
             <div v-for="match in matches" :key="match.id" class="match"
                 :class="match.attributes.state == 1 ? 'match--ended' : 'match--running'">
                 <div class="player-row">
-                    <Player :player="match.attributes['home-team'][0]">
+                    <Player :player="match.attributes['home-team'][0]" style="background-color:#2187E6">
                     </Player>
                     <div class="score score--matches">
                         {{match.attributes['home-team'][0].id == userID ? matchesWon : matchesLost}}
@@ -173,7 +173,7 @@
                 </div>
 
                 <div class="player-row">
-                    <Player :player="match.attributes['away-team'][0]">
+                    <Player :player="match.attributes['away-team'][0]" style="background-color:#F1382A">
                     </Player>
                     <div class="score score--matches">
                         {{match.attributes['away-team'][0].id == userID ? matchesWon : matchesLost}}


### PR DESCRIPTION
Added background color to differentiate Home player (#2187E6) from Away player (#F1382A) so a casual viewer can quickly see which player is on which side of the table and has which score.

Color codes match with Eleven's blue/red color codes for home/away players.