### PR TITLE
added 'show user below' checkbox, which can be used to swap the user rows in page output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Live scoreboard for the [ElevenVR](https://www.elevenvr.net/) Table Tennis game,
 
 1. Open this page: **https://cristy94.github.io/eleven-vr-scoreboard/**
 2. Enter the userID (can be found by clicking on the UserID label, searching for the username and copying the ID shown in the URL)
-3. The latest match of that user is displayed and the score is refreshed every 3 seconds.
+3. If the camera is set up in a way that the mentioned user is to be shown in the bottom half of the screen, check "Show user below"
+4. The latest match of that user is displayed and the score is refreshed every 3 seconds.
 
 ## Usage with OBS
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
             line-height: 1;
         }
 
+        input {
+            margin-right: 15px;
+        }
 
         .match {
             padding: 1rem 2rem;
@@ -156,11 +159,13 @@
         <div id="settings">
             <label for="userID"><a href="https://www.elevenvr.net/search" target="_blank">User ID</a></label>
             <input name="userID" type="text" v-model="userID" @change="userChanged" />
+            <label for="showUserBelow">Show user below</a>
+            <input name="showUserBelow" type="checkbox" v-model="showUserBelow" @change="userChanged" id="swapRows" onClick="swapRows()" />
         </div>
         <div id='matches'>
             <div v-for="match in matches" :key="match.id" class="match"
                 :class="match.attributes.state == 1 ? 'match--ended' : 'match--running'">
-                <div class="player-row">
+                <div class="player-row" id="user">
                     <Player :player="match.attributes['home-team'][0]">
                     </Player>
                     <div class="score score--matches">
@@ -172,7 +177,7 @@
                     </div>
                 </div>
 
-                <div class="player-row">
+                <div class="player-row" id="otherplayer">
                     <Player :player="match.attributes['away-team'][0]">
                     </Player>
                     <div class="score score--matches">
@@ -196,13 +201,33 @@
         const UPDATE_INTERVAL_MS = 3000;
         const LAST_MATCHES_SHOWN_COUNT = 1;
         const USERID_QUERY_PARAM = 'user';
+        const SHOW_USER_BELOW_PARAM = 'showUserBelow';
 
         let updateHandle = 0;
 
         const urlParams = new URLSearchParams(window.location.search);
         const userID = urlParams.get(USERID_QUERY_PARAM);
+        const showUserBelow = urlParams.get(SHOW_USER_BELOW_PARAM);
         const homeWinsOffset = urlParams.get('home-offset') || 0;
         const awayWinOffset = urlParams.get('away-offset') || 0;
+
+        function swapRows() {
+            let userDiv = document.getElementById("user");
+            if ( userDiv !== null ) {
+                let otherPlayerDiv = document.getElementById("otherplayer");
+                let parentDiv = userDiv.parentElement;
+                if ( document.getElementById('swapRows').checked ) {
+                    if ( userDiv.previousSibling === null ) {
+                        parentDiv.insertBefore(otherPlayerDiv, userDiv);
+                    }
+                }
+                else{
+                    if (otherPlayerDiv.previousSibling === null) {
+                        parentDiv.insertBefore(userDiv, otherPlayerDiv);
+                    }
+                }
+            }
+        }
 
         const App = {
             data() {
@@ -212,6 +237,7 @@
                     matches: [],
                     matchesWon: 0,
                     matchesLost: 0,
+                    showUserBelow: showUserBelow || false,
                 }
             },
 
@@ -221,10 +247,13 @@
                 },
                 userChanged() {
                     urlParams.set(USERID_QUERY_PARAM, this.userID);
+                    urlParams.set(SHOW_USER_BELOW_PARAM, this.showUserBelow);
                     history.pushState(null, null, "?" + urlParams.toString());
                     this.updateMatches();
                 },
                 updateMatches() {
+                    swapRows();
+
                     clearTimeout(updateHandle);
                     fetch(`https://www.elevenvr.club/accounts/${this.userID}/matches`)
                         .then(res => res.json())


### PR DESCRIPTION
Can be useful when the stream is showing the "polled user" in the bottom half of the screen.